### PR TITLE
Fix - missing 'j' in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: "Upload release to MavenCentral"
 on:
   release:
     types: [published]
-obs:
+jobs:
   promote:
     runs-on: self-hosted-novum
     steps:


### PR DESCRIPTION
### :goal_net: What's the goal?
Missin 'j' in release.yml

### :construction: How do we do it?
* type j

### :blue_book: Documentation changes?
- [ ] No docs to update nor create

### :test_tube: How can I test this?
- [ ] No tests
