### PR TITLE
Fix - add version and group id

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,11 @@ plugins {
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
 }
 
+allprojects {
+    group = 'com.telefonica.mock'
+    version = System.getProperty("LIBRARY_VERSION") ?: "undefined"
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
### :goal_net: What's the goal?
Add missing version and group id

### :construction: How do we do it?
* provide group id and version

### :blue_book: Documentation changes?
- [ ] No docs to update nor create

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [ ] No tests
