### PR TITLE
Add enqueue functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ class App : Application() {
         ...
         if (BuildConfig.DEFAULT_ENVIRONMENT == Environment.DEMO) {
             CoroutineScope(Dispatchers.IO).launch {
-                mockHelper.startServer()
-                mockHelper.provideDispatcher(getUserMocksUseCase()) // This use case provide a List<Mock>
+                mockHelper.setup()
+                mockHelper.enqueue(getUserMocksUseCase()) // This use case provide a List<Mock>
             }
         }
         ...

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ class App : Application() {
         ...
         if (BuildConfig.DEFAULT_ENVIRONMENT == Environment.DEMO) {
             CoroutineScope(Dispatchers.IO).launch {
-                mockHelper.setup()
+                mockHelper.setUp()
                 mockHelper.enqueue(getUserMocksUseCase()) // This use case provide a List<Mock>
             }
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.telefonica.mocks"
         minSdk 21
         targetSdk 32
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.telefonica.mocks"
         minSdk 21
         targetSdk 32
-        versionCode 2
-        versionName "1.1"
+        versionCode 1
+        versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/telefonica/mocks/App.kt
+++ b/app/src/main/java/com/telefonica/mocks/App.kt
@@ -29,8 +29,8 @@ class App : Application() {
         if (BuildConfig.DEFAULT_ENVIRONMENT == Environment.DEMO) {
             super.onCreate()
             CoroutineScope(Dispatchers.IO).launch {
-                mockHelper.startServer()
-                mockHelper.provideDispatcher(getUserMocksUseCase())
+                mockHelper.setUp()
+                mockHelper.enqueue(getUserMocksUseCase())
                 initBackendUrl()
             }
         }

--- a/mock/src/main/java/com/telefonica/mock/Mock.kt
+++ b/mock/src/main/java/com/telefonica/mock/Mock.kt
@@ -11,7 +11,7 @@ sealed class Method(val value: String) {
 data class Mock(
     val path: String,
     val body: String = "{}",
-    val method: Method? = null,
+    val method: Method,
     val httpResponseCode: Int = 200,
     val delayInMillis: Long = 1000,
 )

--- a/mock/src/main/java/com/telefonica/mock/MockApiClient.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockApiClient.kt
@@ -22,7 +22,7 @@ open class MockApiClient @Inject constructor(
     private val dispatcher = object : Dispatcher() {
         override fun dispatch(request: RecordedRequest): MockResponse {
             val mockFiles: List<Mock> = enqueuedAnswers
-                .filter { mock -> request.method == mock.method?.value }
+                .filter { mock -> request.method == mock.method.value }
                 .filter { mock ->
                     PatternMatcher(
                         mock.path,

--- a/mock/src/main/java/com/telefonica/mock/MockApiClient.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockApiClient.kt
@@ -58,7 +58,7 @@ open class MockApiClient @Inject constructor(
         enqueuedAnswers.addAll(mocks)
     }
 
-    fun setup() {
+    fun setUp() {
         mockWebServer.dispatcher = dispatcher
     }
 

--- a/mock/src/main/java/com/telefonica/mock/MockApiClient.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockApiClient.kt
@@ -11,14 +11,31 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 open class MockApiClient @Inject constructor(
-    private val dispatcher: CoroutineDispatcher,
+    private val coroutineDispatcher: CoroutineDispatcher,
     private val mockWebServer: MockWebServer,
 ) {
 
     private val mockMap: MutableMap<String, List<Mock>> = mutableMapOf()
 
+    private val enqueuedAnswers: MutableList<Mock> = mutableListOf()
+
+    private val dispatcher = object : Dispatcher() {
+        override fun dispatch(request: RecordedRequest): MockResponse {
+            val mockFiles: List<Mock> = enqueuedAnswers
+                .filter { mock -> request.method == mock.method?.value }
+                .filter { mock ->
+                    PatternMatcher(
+                        mock.path,
+                        PatternMatcher.PATTERN_SIMPLE_GLOB
+                    ).match(request.path)
+                }
+
+            return getMockResponse(mockFiles)
+        }
+    }
+
     suspend fun startServer() {
-        withContext(dispatcher) {
+        withContext(coroutineDispatcher) {
             runCatching {
                 mockWebServer.start(port = 0)
             }
@@ -29,25 +46,20 @@ open class MockApiClient @Inject constructor(
         mockWebServer.shutdown()
     }
 
-    suspend fun getBaseUrl(): String = withContext(dispatcher) {
+    suspend fun getBaseUrl(): String = withContext(coroutineDispatcher) {
         mockWebServer.url("/").toString()
     }
 
-    fun provideDispatcher(mocks: List<Mock>) {
-        mockWebServer.dispatcher = object : Dispatcher() {
-            override fun dispatch(request: RecordedRequest): MockResponse {
-                val mockFiles: List<Mock> = mocks
-                    .filter { mock -> request.method == mock.method?.value }
-                    .filter { mock ->
-                        PatternMatcher(
-                            mock.path,
-                            PatternMatcher.PATTERN_SIMPLE_GLOB
-                        ).match(request.path)
-                    }
+    fun enqueue(mock: Mock) {
+        enqueuedAnswers.add(mock)
+    }
 
-                return getMockResponse(mockFiles)
-            }
-        }
+    fun enqueue(mocks: List<Mock>) {
+        enqueuedAnswers.addAll(mocks)
+    }
+
+    fun setup() {
+        mockWebServer.dispatcher = dispatcher
     }
 
     private fun getMockResponse(mockFiles: List<Mock>): MockResponse = when (mockFiles.isEmpty()) {

--- a/mock/src/main/java/com/telefonica/mock/MockHelper.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockHelper.kt
@@ -28,7 +28,7 @@ class MockHelper(context: Context) {
     suspend fun getBaseUrl(): String = mockApiClient.getBaseUrl()
 
     suspend fun setUp() {
-        mockApiClient.setup()
+        mockApiClient.setUp()
         mockApiClient.startServer()
     }
 
@@ -42,7 +42,7 @@ class MockHelper(context: Context) {
 
     fun getMockFromFile(
         path: String,
-        method: Method? = null,
+        method: Method,
         httpResponseCode: Int = 200,
         delayInMillis: Long = 1000,
         localJsonFile: String,
@@ -56,7 +56,7 @@ class MockHelper(context: Context) {
 
     fun getMockFromString(
         path: String,
-        method: Method? = null,
+        method: Method,
         httpResponseCode: Int = 200,
         delayInMillis: Long = 1000,
         body: String,
@@ -70,7 +70,7 @@ class MockHelper(context: Context) {
 
     fun <T> getMockFromObject(
         path: String,
-        method: Method? = null,
+        method: Method,
         httpResponseCode: Int = 200,
         delayInMillis: Long = 1000,
         dataObject: T,
@@ -84,7 +84,7 @@ class MockHelper(context: Context) {
 
     fun <T> getMockFromObject(
         path: String,
-        method: Method? = null,
+        method: Method,
         httpResponseCode: Int = 200,
         delayInMillis: Long = 1000,
         list: List<T>,

--- a/mock/src/main/java/com/telefonica/mock/MockHelper.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockHelper.kt
@@ -21,18 +21,23 @@ class MockHelper(context: Context) {
             .inject(this)
     }
 
-    suspend fun startServer() {
-        mockApiClient.startServer()
-    }
-
     fun stopServer() {
         mockApiClient.stopServer()
     }
 
     suspend fun getBaseUrl(): String = mockApiClient.getBaseUrl()
 
-    fun provideDispatcher(mocks: List<Mock>) {
-        mockApiClient.provideDispatcher(mocks)
+    suspend fun setUp() {
+        mockApiClient.setup()
+        mockApiClient.startServer()
+    }
+
+    fun enqueue(mock: Mock) {
+        mockApiClient.enqueue(mock)
+    }
+
+    fun enqueue(mocks: List<Mock>) {
+        mockApiClient.enqueue(mocks)
     }
 
     fun getMockFromFile(

--- a/mock/src/main/java/com/telefonica/mock/MockProvider.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockProvider.kt
@@ -14,7 +14,7 @@ open class MockProvider @Inject constructor(
 
     open fun fromFile(
         path: String,
-        method: Method? = null,
+        method: Method,
         httpResponseCode: Int,
         delayInMillis: Long,
         localJsonFile: String,
@@ -31,7 +31,7 @@ open class MockProvider @Inject constructor(
 
     open fun fromString(
         path: String,
-        method: Method? = null,
+        method: Method,
         httpResponseCode: Int,
         delayInMillis: Long,
         body: String,
@@ -45,7 +45,7 @@ open class MockProvider @Inject constructor(
 
     open fun <T> fromObject(
         path: String,
-        method: Method? = null,
+        method: Method,
         httpResponseCode: Int,
         delayInMillis: Long,
         dataObject: T
@@ -59,7 +59,7 @@ open class MockProvider @Inject constructor(
 
     open fun <T> fromObject(
         path: String,
-        method: Method? = null,
+        method: Method,
         httpResponseCode: Int,
         delayInMillis: Long,
         list: List<T>


### PR DESCRIPTION
### :goal_net: What's the goal?
In order to let the developer enqueue response, we replace old "provideDispatcher" function by two new functions

enqueue(mock: Mock)
enqueue(mocks: List<Mock)

This way the user can add responses in different parts of the code.

### :construction: How do we do it?
* Remove old function provideDispatcher
* Create a mutable list to store reponses
* Create functions to fill the mutable list with responses.

### :blue_book: Documentation changes?
- [ ] No docs to update nor create

### :test_tube: How can I test this?
- [ ] No tests
