### PR TITLE
Adding ssl support

### DIFF
--- a/app/src/demo/assets/user_list_success_2.json
+++ b/app/src/demo/assets/user_list_success_2.json
@@ -6,8 +6,8 @@
         "first": "Pablo",
         "last": "Garcia"
       },
-      "email": "Pablogarcia.sg@gmail.com",
-      "phone": "618 42 69 62"
+      "email": "Pablo.Garcia@gmail.com",
+      "phone": "666 66 66 66"
     },
     {
       "name": {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,8 +15,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.Mocks"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/telefonica/mocks/App.kt
+++ b/app/src/main/java/com/telefonica/mocks/App.kt
@@ -1,6 +1,7 @@
 package com.telefonica.mocks
 
 import android.app.Application
+import android.util.Log
 import com.telefonica.mock.MockHelper
 import com.telefonica.mocks.common.Environment
 import com.telefonica.mocks.domain.backend.InitBackendUrl
@@ -9,6 +10,7 @@ import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.net.InetAddress
 import javax.inject.Inject
 
 
@@ -29,7 +31,7 @@ class App : Application() {
         if (BuildConfig.DEFAULT_ENVIRONMENT == Environment.DEMO) {
             super.onCreate()
             CoroutineScope(Dispatchers.IO).launch {
-                mockHelper.setUp()
+                mockHelper.setUp(enableSsl = true)
                 mockHelper.enqueue(getUserMocksUseCase())
                 initBackendUrl()
             }

--- a/app/src/main/java/com/telefonica/mocks/App.kt
+++ b/app/src/main/java/com/telefonica/mocks/App.kt
@@ -1,7 +1,6 @@
 package com.telefonica.mocks
 
 import android.app.Application
-import android.util.Log
 import com.telefonica.mock.MockHelper
 import com.telefonica.mocks.common.Environment
 import com.telefonica.mocks.domain.backend.InitBackendUrl
@@ -10,7 +9,6 @@ import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.net.InetAddress
 import javax.inject.Inject
 
 

--- a/app/src/main/java/com/telefonica/mocks/di/RemoteModule.kt
+++ b/app/src/main/java/com/telefonica/mocks/di/RemoteModule.kt
@@ -6,6 +6,7 @@ import com.telefonica.mocks.domain.backend.InitBackendUrl
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.telefonica.mock.MockHelper
+import com.telefonica.mock.cert.AllCertsAllowedBuilderUpdater
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -29,7 +30,12 @@ class RemoteModule {
     @Provides
     fun provideOkHttpClient(
         interceptor: HttpLoggingInterceptor
-    ): OkHttpClient = OkHttpClient.Builder().addInterceptor(interceptor).build()
+    ): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(interceptor)
+        .apply {
+            AllCertsAllowedBuilderUpdater.update(this)
+        }
+        .build()
 
     @Provides
     fun provideMoshi(): Moshi = Moshi

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+	<debug-overrides>
+		<trust-anchors>
+			<!-- Trust user added CAs while debuggable only -->
+			<certificates src="user" />
+		</trust-anchors>
+	</debug-overrides>
+</network-security-config>

--- a/mock/build.gradle
+++ b/mock/build.gradle
@@ -34,6 +34,7 @@ android {
 dependencies {
 
     implementation "com.squareup.okhttp3:mockwebserver:4.9.3"
+    implementation "com.squareup.okhttp3:okhttp-tls:4.9.3"
 
     implementation "com.google.dagger:dagger:2.44"
     kapt "com.google.dagger:dagger-compiler:2.44"

--- a/mock/src/main/java/com/telefonica/mock/MockApiClient.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockApiClient.kt
@@ -7,6 +7,8 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import okhttp3.tls.HandshakeCertificates
+import okhttp3.tls.HeldCertificate
 import java.net.InetAddress
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -35,7 +37,7 @@ open class MockApiClient @Inject constructor(
         }
     }
 
-    suspend fun startServer(inetAddress: InetAddress = InetAddress.getByName("localhost"), port: Int = 0) {
+    internal suspend fun startServer(inetAddress: InetAddress, port: Int = 0) {
         withContext(coroutineDispatcher) {
             runCatching {
                 mockWebServer.start(inetAddress = inetAddress, port = port)
@@ -59,9 +61,24 @@ open class MockApiClient @Inject constructor(
         enqueuedAnswers.addAll(mocks)
     }
 
-    fun setUp() {
+    internal fun setUp(address: InetAddress, enableSsl: Boolean) {
         mockWebServer.dispatcher = dispatcher
+        if (enableSsl) {
+            enableHttpsFor(mockWebServer, address)
+        }
     }
+
+    private fun enableHttpsFor(mockWebServer: MockWebServer, address: InetAddress) {
+        val serverCertificates = HandshakeCertificates.Builder()
+            .heldCertificate(buildCertificate(address.canonicalHostName))
+            .build()
+        mockWebServer.useHttps(serverCertificates.sslSocketFactory(), false)
+    }
+
+    private fun buildCertificate(altName: String): HeldCertificate = HeldCertificate.Builder()
+        .addSubjectAlternativeName(altName)
+        .build()
+
 
     private fun getMockResponse(mockFiles: List<Mock>): MockResponse = when (mockFiles.isEmpty()) {
         true -> MockResponse().setResponseCode(NOT_FOUND_ERROR)

--- a/mock/src/main/java/com/telefonica/mock/MockApiClient.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockApiClient.kt
@@ -7,6 +7,7 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import java.net.InetAddress
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -34,10 +35,10 @@ open class MockApiClient @Inject constructor(
         }
     }
 
-    suspend fun startServer() {
+    suspend fun startServer(inetAddress: InetAddress = InetAddress.getByName("localhost"), port: Int = 0) {
         withContext(coroutineDispatcher) {
             runCatching {
-                mockWebServer.start(port = 0)
+                mockWebServer.start(inetAddress = inetAddress, port = port)
             }
         }
     }

--- a/mock/src/main/java/com/telefonica/mock/MockHelper.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockHelper.kt
@@ -3,6 +3,7 @@ package com.telefonica.mock
 import android.content.Context
 import com.telefonica.mock.di.DaggerMockComponent
 import com.telefonica.mock.di.MockApiModule
+import java.net.InetAddress
 import javax.inject.Inject
 
 class MockHelper(context: Context) {
@@ -27,9 +28,9 @@ class MockHelper(context: Context) {
 
     suspend fun getBaseUrl(): String = mockApiClient.getBaseUrl()
 
-    suspend fun setUp() {
+    suspend fun setUp(inetAddress: InetAddress = InetAddress.getByName("localhost"), port: Int = 0) {
         mockApiClient.setUp()
-        mockApiClient.startServer()
+        mockApiClient.startServer(inetAddress, port)
     }
 
     fun enqueue(mock: Mock) {

--- a/mock/src/main/java/com/telefonica/mock/MockHelper.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockHelper.kt
@@ -28,8 +28,15 @@ class MockHelper(context: Context) {
 
     suspend fun getBaseUrl(): String = mockApiClient.getBaseUrl()
 
-    suspend fun setUp(inetAddress: InetAddress = InetAddress.getByName("localhost"), port: Int = 0) {
-        mockApiClient.setUp()
+    suspend fun setUp(
+        inetAddress: InetAddress = InetAddress.getByName("localhost"),
+        port: Int = 0,
+        enableSsl: Boolean = false,
+    ) {
+        mockApiClient.setUp(
+            address = inetAddress,
+            enableSsl = enableSsl,
+        )
         mockApiClient.startServer(inetAddress, port)
     }
 

--- a/mock/src/main/java/com/telefonica/mock/cert/AllCertsAllowedBuilderUpdater.kt
+++ b/mock/src/main/java/com/telefonica/mock/cert/AllCertsAllowedBuilderUpdater.kt
@@ -1,0 +1,47 @@
+package com.telefonica.mock.cert
+
+import android.annotation.SuppressLint
+import okhttp3.OkHttpClient
+import java.security.KeyManagementException
+import java.security.NoSuchAlgorithmException
+import java.security.cert.CertificateException
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+
+object AllCertsAllowedBuilderUpdater {
+
+    @SuppressLint("CustomX509TrustManager")
+    @JvmStatic
+    fun update(builder: OkHttpClient.Builder) {
+        val trustAllCerts = arrayOf<TrustManager>(object : X509TrustManager {
+            @SuppressLint("TrustAllX509TrustManager")
+            @Throws(CertificateException::class)
+            override fun checkClientTrusted(chain: Array<java.security.cert.X509Certificate>, authType: String) {
+            }
+
+            @SuppressLint("TrustAllX509TrustManager")
+            @Throws(CertificateException::class)
+            override fun checkServerTrusted(chain: Array<java.security.cert.X509Certificate>, authType: String) {
+            }
+
+            override fun getAcceptedIssuers(): Array<java.security.cert.X509Certificate> {
+                return arrayOf()
+            }
+        })
+
+        try {
+            val sslContext = SSLContext.getInstance("SSL")
+            sslContext.init(null, trustAllCerts, java.security.SecureRandom())
+            val sslSocketFactory = sslContext.socketFactory
+            builder.sslSocketFactory(sslSocketFactory, trustAllCerts[0] as X509TrustManager)
+            builder.hostnameVerifier(HostnameVerifier { _, _ -> true })
+        } catch (e: NoSuchAlgorithmException) {
+            throw RuntimeException(e)
+        } catch (e: KeyManagementException) {
+            throw RuntimeException(e)
+        }
+    }
+
+}


### PR DESCRIPTION
### :goal_net: What's the goal?
Adding full support for SSL connections, so users of this app can remove the clear text traffic flag.

### :construction: How do we do it?
Following [this approach](https://adambennett.dev/2021/09/mockwebserver--https/) with a memory hosted certificate

### :test_tube: How can I test this?
The demo app is now running with ssl