### PR TITLE
Make setup function not suspend

### DIFF
--- a/app/src/main/java/com/telefonica/mocks/App.kt
+++ b/app/src/main/java/com/telefonica/mocks/App.kt
@@ -28,9 +28,9 @@ class App : Application() {
 
         if (BuildConfig.DEFAULT_ENVIRONMENT == Environment.DEMO) {
             super.onCreate()
+            mockHelper.setUp(enableSsl = true)
+            getUserMocksUseCase()
             CoroutineScope(Dispatchers.IO).launch {
-                mockHelper.setUp(enableSsl = true)
-                getUserMocksUseCase()
                 initBackendUrl()
             }
         }

--- a/mock/src/main/java/com/telefonica/mock/MockHelper.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockHelper.kt
@@ -30,20 +30,12 @@ class MockHelper(context: Context) {
 
     suspend fun getBaseUrl(): String = mockApiClient.getBaseUrl()
 
-    suspend fun setUp(
-        inetAddress: InetAddress = InetAddress.getByName(DEFAULT_HOSTNAME),
+    fun setUp(
         port: Int = 0,
         enableSsl: Boolean = false,
     ) {
-        mockApiClient.setUp(
-            address = inetAddress,
-            enableSsl = enableSsl,
-        )
-        mockApiClient.startServer(inetAddress, port)
-    }
-
-    companion object {
-        const val DEFAULT_HOSTNAME = "localhost"
+        mockApiClient.setUp(enableSsl = enableSsl)
+        mockApiClient.startServer(port)
     }
 }
 

--- a/mock/src/main/java/com/telefonica/mock/MockedServer.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockedServer.kt
@@ -25,9 +25,7 @@ open class MockedServer @Inject constructor(
     }
 
     internal fun startServer(port: Int = 0) {
-        runCatching {
-            mockWebServer.start(port = port)
-        }
+        mockWebServer.start(port = port)
     }
 
     fun stopServer() {

--- a/mock/src/main/java/com/telefonica/mock/MockedServer.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockedServer.kt
@@ -24,11 +24,9 @@ open class MockedServer @Inject constructor(
         )
     }
 
-    internal suspend fun startServer(inetAddress: InetAddress, port: Int = 0) {
-        withContext(coroutineDispatcher) {
-            runCatching {
-                mockWebServer.start(inetAddress = inetAddress, port = port)
-            }
+    internal fun startServer(port: Int = 0) {
+        runCatching {
+            mockWebServer.start(port = port)
         }
     }
 
@@ -44,22 +42,22 @@ open class MockedServer @Inject constructor(
         responseDispatcher.enqueue(requestInfo, mockedResponse)
     }
 
-    internal fun setUp(address: InetAddress, enableSsl: Boolean) {
+    internal fun setUp(enableSsl: Boolean) {
         mockWebServer.dispatcher = dispatcher
         if (enableSsl) {
-            enableHttpsFor(mockWebServer, address)
+            enableHttpsFor(mockWebServer)
         }
     }
 
-    private fun enableHttpsFor(mockWebServer: MockWebServer, address: InetAddress) {
+    private fun enableHttpsFor(mockWebServer: MockWebServer) {
         val serverCertificates = HandshakeCertificates.Builder()
-            .heldCertificate(buildCertificate(address.canonicalHostName))
+            .heldCertificate(buildCertificate())
             .build()
         mockWebServer.useHttps(serverCertificates.sslSocketFactory(), false)
     }
 
-    private fun buildCertificate(altName: String): HeldCertificate = HeldCertificate.Builder()
-        .addSubjectAlternativeName(altName)
+    private fun buildCertificate(): HeldCertificate = HeldCertificate.Builder()
+        .addSubjectAlternativeName("localhost")
         .build()
 
     companion object {


### PR DESCRIPTION
### :goal_net: What's the goal?
Making setup function not suspend, we avoid possibles race conditions

### :construction: How do we do it?
* As we are doing in other apps, set default certificate name as "localhost" instead of use suspend InetAddress.getByName function

### :blue_book: Documentation changes?
- [ ] No docs to update nor create

### :test_tube: How can I test this?
_If it cannot be tested explain why._
- [ ] No tests
