### PR TITLE
Endpoint path matching enhanced with multiple possible matching patterns

### DIFF
--- a/mock/src/main/java/com/telefonica/mock/MockHelper.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockHelper.kt
@@ -1,7 +1,6 @@
 package com.telefonica.mock
 
 import android.content.Context
-import android.os.PatternMatcher.PATTERN_SIMPLE_GLOB
 import com.telefonica.mock.di.DaggerMockComponent
 import com.telefonica.mock.di.MockApiModule
 import javax.inject.Inject
@@ -42,9 +41,8 @@ class MockHelper(context: Context) {
 class EnqueuingContext(val mockHelper: MockHelper) {
     fun whenever(
         path: Path,
-        method: Method = Method.Get,
-        matchingPattern: Int = PATTERN_SIMPLE_GLOB
-    ): MockResponseBuilderWithRequestInfo = MockResponseBuilderWithRequestInfo(mockHelper, RequestInfo(path, method, matchingPattern))
+        method: Method = Method.Get
+    ): MockResponseBuilderWithRequestInfo = MockResponseBuilderWithRequestInfo(mockHelper, RequestInfo(path, method))
 }
 
 class MockResponseBuilderWithRequestInfo(

--- a/mock/src/main/java/com/telefonica/mock/MockHelper.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockHelper.kt
@@ -1,9 +1,9 @@
 package com.telefonica.mock
 
 import android.content.Context
+import android.os.PatternMatcher.PATTERN_SIMPLE_GLOB
 import com.telefonica.mock.di.DaggerMockComponent
 import com.telefonica.mock.di.MockApiModule
-import java.net.InetAddress
 import javax.inject.Inject
 
 class MockHelper(context: Context) {
@@ -43,7 +43,8 @@ class EnqueuingContext(val mockHelper: MockHelper) {
     fun whenever(
         path: Path,
         method: Method = Method.Get,
-    ): MockResponseBuilderWithRequestInfo = MockResponseBuilderWithRequestInfo(mockHelper, RequestInfo(path, method))
+        matchingPattern: Int = PATTERN_SIMPLE_GLOB
+    ): MockResponseBuilderWithRequestInfo = MockResponseBuilderWithRequestInfo(mockHelper, RequestInfo(path, method, matchingPattern))
 }
 
 class MockResponseBuilderWithRequestInfo(

--- a/mock/src/main/java/com/telefonica/mock/MockedServer.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockedServer.kt
@@ -6,7 +6,6 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
-import java.net.InetAddress
 import okhttp3.tls.HandshakeCertificates
 import okhttp3.tls.HeldCertificate
 import javax.inject.Inject

--- a/mock/src/main/java/com/telefonica/mock/ResponseDispatcher.kt
+++ b/mock/src/main/java/com/telefonica/mock/ResponseDispatcher.kt
@@ -15,7 +15,10 @@ class ResponseDispatcher @Inject constructor() {
 
     fun dispatch(recordedMethod: String?, recordedPath: String?): MockResponse {
         val responseList = responses
-            .filterKeys { requestInfo -> requestInfo.method.value == recordedMethod && requestInfo.path.toPattern().match(recordedPath) }
+            .filterKeys { requestInfo ->
+                requestInfo.method.value == recordedMethod
+                        && requestInfo.path.toPattern(requestInfo.matchingPattern).match(recordedPath)
+            }
             .entries
             .firstOrNull()
             ?.value
@@ -45,5 +48,5 @@ class ResponseDispatcher @Inject constructor() {
         responses[requestInfo] = mockListUpdated
     }
 
-    private fun Path.toPattern(): PatternMatcher = PatternMatcher(this, PatternMatcher.PATTERN_SIMPLE_GLOB)
+    private fun Path.toPattern(pattern: Int): PatternMatcher = PatternMatcher(this, pattern)
 }

--- a/mock/src/main/java/com/telefonica/mock/ResponseDispatcher.kt
+++ b/mock/src/main/java/com/telefonica/mock/ResponseDispatcher.kt
@@ -1,6 +1,5 @@
 package com.telefonica.mock
 
-import android.os.PatternMatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.SocketPolicy
 import java.util.*
@@ -16,8 +15,7 @@ class ResponseDispatcher @Inject constructor() {
     fun dispatch(recordedMethod: String?, recordedPath: String?): MockResponse {
         val responseList = responses
             .filterKeys { requestInfo ->
-                requestInfo.method.value == recordedMethod
-                        && requestInfo.path.toPattern(requestInfo.matchingPattern).match(recordedPath)
+                requestInfo.method.value == recordedMethod && !recordedPath.isNullOrEmpty() && Regex(requestInfo.path).matches(recordedPath)
             }
             .entries
             .firstOrNull()
@@ -47,6 +45,4 @@ class ResponseDispatcher @Inject constructor() {
         val mockListUpdated = (responses[requestInfo] ?: LinkedList()).apply { add(mockedResponse) }
         responses[requestInfo] = mockListUpdated
     }
-
-    private fun Path.toPattern(pattern: Int): PatternMatcher = PatternMatcher(this, pattern)
 }

--- a/mock/src/main/java/com/telefonica/mock/models.kt
+++ b/mock/src/main/java/com/telefonica/mock/models.kt
@@ -45,7 +45,7 @@ class MockedBufferedResponse(
 
 internal class RequestAndResponse(val requestInfo: RequestInfo, val mockedResponse: MockedResponse)
 
-data class RequestInfo(val path: Path, val method: Method)
+data class RequestInfo(val path: Path, val method: Method, val matchingPattern: Int)
 typealias Path=String
 
 internal class RequestInfoWithPattern(val pathPattern: PatternMatcher, val method: Method)

--- a/mock/src/main/java/com/telefonica/mock/models.kt
+++ b/mock/src/main/java/com/telefonica/mock/models.kt
@@ -45,7 +45,7 @@ class MockedBufferedResponse(
 
 internal class RequestAndResponse(val requestInfo: RequestInfo, val mockedResponse: MockedResponse)
 
-data class RequestInfo(val path: Path, val method: Method, val matchingPattern: Int)
+data class RequestInfo(val path: Path, val method: Method)
 typealias Path=String
 
 internal class RequestInfoWithPattern(val pathPattern: PatternMatcher, val method: Method)


### PR DESCRIPTION
### :goal_net: What's the goal?
_Allowing complex regular expressions in endpoint path matching._

### :construction: How do we do it?
_The idea is to add a new RequestInfo parameter allowing the developer to specify a pattern matcher type. Prior to these changes, the pattern was set as **PatternMatcher.PATTERN_SIMPLE_GLOB** by default._

_There is a problem with **PatternMatcher.PATTERN_SIMPLE_GLOB** though, it only accepts '.' and '*' as valid matching characters, what leads us to a necessary change._

_The first approach was changing the already in use pattern matcher type to **PatternMatcher.PATTERN_ADVANCED_GLOB**. The problem with that one is that **it requires 26 as the minimum API level** and ours is 21._

_Another idea was changing it to **PatternMatcher.PATTERN_LITERAL** but this one would not accept the current ".*" expression already in use._

_Given these obstacles I opted for adding a new parameter set as **PatternMatcher.PATTERN_SIMPLE_GLOB** by default, so that no further change would be required in any project. With this new parameter, we can pass any pattern we want, preferably **PatternMatcher.PATTERN_LITERAL** since this one allows for classic complex regular expressions._

### :blue_book: Documentation changes?
- [ ] No docs to update nor create

### :test_tube: How can I test this?
_In order to test this, it will be necessary to add matchingPattern = "your_regex" within the whenever() function and check its working._
