### PR TITLE
Remove suspend keyword from getBaseUrl function #ANDROID-15254

### DIFF
--- a/app/src/main/java/com/telefonica/mocks/domain/backend/InitBackendUrl.kt
+++ b/app/src/main/java/com/telefonica/mocks/domain/backend/InitBackendUrl.kt
@@ -4,18 +4,14 @@ import com.telefonica.mock.MockHelper
 import com.telefonica.mocks.BuildConfig
 import com.telefonica.mocks.common.Environment
 import com.telefonica.mocks.data.backend.BackendRepository
-import com.telefonica.mocks.di.IoDispatcher
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 open class InitBackendUrl @Inject constructor(
     private val mockHelper: MockHelper,
     private val backendRepository: BackendRepository,
-    @IoDispatcher private val dispatcher: CoroutineDispatcher,
 ) {
 
-    open suspend operator fun invoke() = withContext(dispatcher) {
+    open suspend operator fun invoke() {
         backendRepository.backendUrl = when (BuildConfig.DEFAULT_ENVIRONMENT == Environment.DEMO) {
             true -> mockHelper.getBaseUrl()
             false -> BuildConfig.DEFAULT_ENVIRONMENT.baseUrl

--- a/app/src/main/java/com/telefonica/mocks/domain/backend/InitBackendUrl.kt
+++ b/app/src/main/java/com/telefonica/mocks/domain/backend/InitBackendUrl.kt
@@ -11,7 +11,7 @@ open class InitBackendUrl @Inject constructor(
     private val backendRepository: BackendRepository,
 ) {
 
-    open suspend operator fun invoke() {
+    open operator fun invoke() {
         backendRepository.backendUrl = when (BuildConfig.DEFAULT_ENVIRONMENT == Environment.DEMO) {
             true -> mockHelper.getBaseUrl()
             false -> BuildConfig.DEFAULT_ENVIRONMENT.baseUrl

--- a/mock/src/main/java/com/telefonica/mock/MockHelper.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockHelper.kt
@@ -27,7 +27,7 @@ class MockHelper(context: Context) {
         mockApiClient.stopServer()
     }
 
-    suspend fun getBaseUrl(): String = mockApiClient.getBaseUrl()
+    fun getBaseUrl(): String = mockApiClient.getBaseUrl()
 
     fun setUp(
         port: Int = 0,

--- a/mock/src/main/java/com/telefonica/mock/MockedServer.kt
+++ b/mock/src/main/java/com/telefonica/mock/MockedServer.kt
@@ -1,7 +1,5 @@
 package com.telefonica.mock
 
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -11,7 +9,6 @@ import okhttp3.tls.HeldCertificate
 import javax.inject.Inject
 
 open class MockedServer @Inject constructor(
-    private val coroutineDispatcher: CoroutineDispatcher,
     private val mockWebServer: MockWebServer,
     private val responseDispatcher: ResponseDispatcher,
 ) {
@@ -31,9 +28,7 @@ open class MockedServer @Inject constructor(
         mockWebServer.shutdown()
     }
 
-    suspend fun getBaseUrl(): String = withContext(coroutineDispatcher) {
-        mockWebServer.url("/").toString()
-    }
+    fun getBaseUrl(): String = mockWebServer.url("/").toString()
 
     internal fun enqueue(requestInfo: RequestInfo, mockedResponse: MockedResponse) {
         responseDispatcher.enqueue(requestInfo, mockedResponse)

--- a/mock/src/main/java/com/telefonica/mock/di/MockApiModule.kt
+++ b/mock/src/main/java/com/telefonica/mock/di/MockApiModule.kt
@@ -27,5 +27,5 @@ class MockApiModule(private val context: Context) {
     fun provideMockApiClient(
         mockWebServer: MockWebServer,
         responseDispatcher: ResponseDispatcher,
-    ): MockedServer = MockedServer(Dispatchers.IO, mockWebServer, responseDispatcher)
+    ): MockedServer = MockedServer(mockWebServer, responseDispatcher)
 }


### PR DESCRIPTION
### :goal_net: What's the goal?
Make not suspend getBaseUrl function.

### :construction: How do we do it?
* _Remove suspend from getBaseUrl function_
* _Remove withContext from InitBackendUrl_

### :blue_book: Documentation changes?
- [x] No docs to update nor create

### :test_tube: How can I test this?
Launch the app and see that everything is working fine
