### PR TITLE
Fix NoWhenBranchMatchedException #ANDROID-15269

### DIFF
--- a/mock/src/main/java/com/telefonica/mock/ResponseDispatcher.kt
+++ b/mock/src/main/java/com/telefonica/mock/ResponseDispatcher.kt
@@ -24,7 +24,7 @@ class ResponseDispatcher @Inject constructor() {
         return when {
             responseList.isNullOrEmpty() -> MockResponse().setResponseCode(MockedServer.RESPONSE_NOT_FOUND_CODE)
             else -> {
-                val response = responseList.poll()
+                val response = responseList.poll() ?: return MockResponse().setResponseCode(MockedServer.RESPONSE_NOT_FOUND_CODE)
                 responseList.add(response)
                 when (response) {
                     is MockedApiResponse -> MockResponse()

--- a/mock/src/main/java/com/telefonica/mock/models.kt
+++ b/mock/src/main/java/com/telefonica/mock/models.kt
@@ -12,8 +12,8 @@ sealed class Method(val value: String) {
 }
 
 sealed class MockedResponse(
-    val httpResponseCode: Int = DEFAULT_MOCK_HTTP_RESPONSE_CODE,
-    val delayInMillis: Long = DEFAULT_MOCK_DELAY_IN_MILLIS,
+    open val httpResponseCode: Int = DEFAULT_MOCK_HTTP_RESPONSE_CODE,
+    open val delayInMillis: Long = DEFAULT_MOCK_DELAY_IN_MILLIS,
 ) {
     companion object {
         const val DEFAULT_MOCK_DELAY_IN_MILLIS = 0L
@@ -21,10 +21,10 @@ sealed class MockedResponse(
     }
 }
 
-class MockedApiResponse(
+data class MockedApiResponse(
     val body: String = DEFAULT_BODY,
-    httpResponseCode: Int = DEFAULT_MOCK_HTTP_RESPONSE_CODE,
-    delayInMillis: Long = DEFAULT_MOCK_DELAY_IN_MILLIS,
+    override val httpResponseCode: Int = DEFAULT_MOCK_HTTP_RESPONSE_CODE,
+    override val delayInMillis: Long = DEFAULT_MOCK_DELAY_IN_MILLIS,
 ) : MockedResponse(
     httpResponseCode,
     delayInMillis,
@@ -34,10 +34,10 @@ class MockedApiResponse(
     }
 }
 
-class MockedBufferedResponse(
+data class MockedBufferedResponse(
     val buffer: Buffer,
-    httpResponseCode: Int = DEFAULT_MOCK_HTTP_RESPONSE_CODE,
-    delayInMillis: Long = DEFAULT_MOCK_DELAY_IN_MILLIS,
+    override val httpResponseCode: Int = DEFAULT_MOCK_HTTP_RESPONSE_CODE,
+    override val delayInMillis: Long = DEFAULT_MOCK_DELAY_IN_MILLIS,
 ) : MockedResponse(
     httpResponseCode,
     delayInMillis,


### PR DESCRIPTION
### :goal_net: What's the goal?
Fix NoWhenBranchMatchedException. 
![Captura de pantalla 2024-10-07 a las 13 43 59](https://github.com/user-attachments/assets/b32ae8b0-22ef-4b6b-83f9-c5e62251fcdd)

### :construction: How do we do it?
* _`poll()` method could return a null. Now, if null is retrieved from `responseList` we return MockedResponse with RESPONSE_NOT_FOUND_CODE_
* _We assure there are no more than two possibilities inside when (MockedApiResponse or MockedBufferedResponse)_

### :blue_book: Documentation changes?
- [x] No docs to update nor create

### :test_tube: How can I test this?
- [x] I've created [this pr](https://github.com/Telefonica/niji-for-home-android/actions/runs/11214611339/job/31170045841?pr=1778#logs) in which I've applied this same change to a local mock api lib. You can see how all tests [have been passed](https://github.com/Telefonica/niji-for-home-android/actions/runs/11214611339/job/31170045841?pr=1778#logs:~:text=%5BMon%20Oct%2007%2011%3A59%3A38%20UTC%202024%5D%3A%20Test,936)

