### PR TITLE
Update libs ANDROID-17152

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,9 +43,6 @@ android {
     buildFeatures {
         compose true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion "1.4.7"
-    }
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
     id 'kotlin-kapt'
     id 'dagger.hilt.android.plugin'
 }
@@ -11,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "com.telefonica.mocks"
-        minSdk 21
+        minSdk 23
         targetSdk 36
         versionCode 1
         versionName "1.0"
@@ -48,6 +49,7 @@ android {
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
+            excludes += "META-INF/versions/*/OSGI-INF/*"
         }
     }
 
@@ -76,23 +78,23 @@ dependencies {
 
     implementation project(":mock")
 
-    implementation("com.google.dagger:hilt-android:2.46.1")
-    implementation "androidx.hilt:hilt-navigation-compose:1.0.0"
+    implementation("com.google.dagger:hilt-android:2.57.2")
+    implementation "androidx.hilt:hilt-navigation-compose:1.3.0"
 
-    implementation 'androidx.navigation:navigation-runtime-ktx:2.5.2'
-    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation 'androidx.navigation:navigation-runtime-ktx:2.9.6'
+    implementation 'androidx.core:core-ktx:1.17.0'
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
-    implementation 'androidx.activity:activity-compose:1.5.0'
-    implementation "androidx.navigation:navigation-compose:2.5.2"
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.10.0'
+    implementation 'androidx.activity:activity-compose:1.12.2'
+    implementation "androidx.navigation:navigation-compose:2.9.6"
 
-    implementation "com.squareup.retrofit2:retrofit:2.9.0"
-    implementation "com.squareup.retrofit2:converter-moshi:2.9.0"
-    implementation "com.squareup.moshi:moshi-kotlin:1.13.0"
-    implementation "com.squareup.okhttp3:logging-interceptor:4.10.0"
+    implementation "com.squareup.retrofit2:retrofit:3.0.0"
+    implementation "com.squareup.retrofit2:converter-moshi:3.0.0"
+    implementation "com.squareup.moshi:moshi-kotlin:1.15.2"
+    implementation "com.squareup.okhttp3:logging-interceptor:5.3.2"
 
-    kapt("com.google.dagger:hilt-android-compiler:2.46.1")
+    kapt("com.google.dagger:hilt-android-compiler:2.57.2")
 
 }

--- a/app/src/main/java/com/telefonica/mocks/MainActivity.kt
+++ b/app/src/main/java/com/telefonica/mocks/MainActivity.kt
@@ -3,7 +3,9 @@ package com.telefonica.mocks
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
@@ -19,12 +21,13 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         setContent {
             MocksTheme {
                 Surface(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize().safeDrawingPadding(),
                     color = MaterialTheme.colors.background
                 ) {
                     InitialScreen()

--- a/app/src/main/java/com/telefonica/mocks/ui/common/Composables.kt
+++ b/app/src/main/java/com/telefonica/mocks/ui/common/Composables.kt
@@ -11,13 +11,13 @@ import androidx.compose.material.Card
 import androidx.compose.material.Icon
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.telefonica.mocks.R
 import com.telefonica.mocks.model.user.UserBo
 
 @Composable
@@ -43,7 +43,7 @@ fun Error(message: String) {
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Icon(
-                imageVector = Icons.Rounded.Warning,
+                painter = painterResource(R.drawable.rounded_warning),
                 contentDescription = null,
                 tint = Color.Yellow
             )

--- a/app/src/main/java/com/telefonica/mocks/ui/seconduserlist/SecondUserListScreen.kt
+++ b/app/src/main/java/com/telefonica/mocks/ui/seconduserlist/SecondUserListScreen.kt
@@ -1,19 +1,22 @@
 package com.telefonica.mocks.ui.seconduserlist
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.*
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import com.telefonica.mocks.R
 import com.telefonica.mocks.ui.common.Error
 import com.telefonica.mocks.ui.common.Loading
 import com.telefonica.mocks.ui.common.UserList
@@ -45,7 +48,10 @@ fun SecondUserListScreen(
                 },
                 navigationIcon = {
                     IconButton(onClick = { onBackButtonClicked() }) {
-                        Icon(imageVector = Icons.Default.ArrowBack, contentDescription = null)
+                        Icon(
+                            painter = painterResource(R.drawable.arrow_back),
+                            contentDescription = null
+                        )
                     }
                 },
                 backgroundColor = Color.White,

--- a/app/src/main/java/com/telefonica/mocks/ui/userlist/UserListScreen.kt
+++ b/app/src/main/java/com/telefonica/mocks/ui/userlist/UserListScreen.kt
@@ -9,15 +9,13 @@ import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.telefonica.mocks.ui.common.Error
 import com.telefonica.mocks.ui.common.Loading
@@ -49,7 +47,10 @@ fun UserListScreen(
                     contentColor = Color.White,
                     backgroundColor = MaterialTheme.colors.primary
                 ) {
-                    Icon(imageVector = Icons.Filled.Refresh, contentDescription = null)
+                    Icon(
+                        painter = painterResource(com.telefonica.mocks.R.drawable.refresh),
+                        contentDescription = null,
+                    )
                 }
 
                 FloatingActionButton(
@@ -58,7 +59,10 @@ fun UserListScreen(
                     contentColor = Color.White,
                     backgroundColor = MaterialTheme.colors.primaryVariant
                 ) {
-                    Icon(imageVector = Icons.Filled.KeyboardArrowRight, contentDescription = null)
+                    Icon(
+                        painter = painterResource(com.telefonica.mocks.R.drawable.keyboard_arrow_right),
+                        contentDescription = null,
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/telefonica/mocks/ui/userlist/navigation/UserListNavigation.kt
+++ b/app/src/main/java/com/telefonica/mocks/ui/userlist/navigation/UserListNavigation.kt
@@ -1,6 +1,6 @@
 package com.telefonica.mocks.ui.userlist.navigation
 
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable

--- a/app/src/main/res/drawable/arrow_back.xml
+++ b/app/src/main/res/drawable/arrow_back.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8l8,8l1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/app/src/main/res/drawable/keyboard_arrow_right.xml
+++ b/app/src/main/res/drawable/keyboard_arrow_right.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M8.59,16.59L13.17,12L8.59,7.41L10,6l6,6l-6,6l-1.41,-1.41z"/>
+</vector>

--- a/app/src/main/res/drawable/refresh.xml
+++ b/app/src/main/res/drawable/refresh.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M17.65,6.35C16.2,4.9,14.21,4,12,4c-4.42,0-7.99,3.58-7.99,8S7.58,20,12,20c3.73,0,6.84-2.55,7.73-6h-2.08c-0.82,2.33-3.04,4-5.65,4-3.31,0-6-2.69-6-6s2.69-6,6-6c1.66,0,3.14,0.69,4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+</vector>

--- a/app/src/main/res/drawable/rounded_warning.xml
+++ b/app/src/main/res/drawable/rounded_warning.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4.47,21h15.06c1.54,0,2.5,-1.67,1.73,-3L13.73,4.99c-0.77,-1.33,-2.69,-1.33,-3.46,0L2.74,18c-0.77,1.33,0.19,3,1.73,3z
+            M12,14c-0.55,0,-1,-0.45,-1,-1v-2c0,-0.55,0.45,-1,1,-1s1,0.45,1,1v2c0,0.55,-0.45,1,-1,1z
+            M13,18h-2v-2h2v2z"/>
+</vector>

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,17 @@
 buildscript {
     ext {
-        compose_version = '1.2.0-beta01'
+        compose_version = '1.10.0'
     }
     dependencies {
-        classpath "com.google.dagger:hilt-android-gradle-plugin:2.46.1"
+        classpath "com.google.dagger:hilt-android-gradle-plugin:2.57.2"
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '8.11.1' apply false
     id 'com.android.library' version '8.11.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.21' apply false
+    id 'org.jetbrains.kotlin.android' version '2.2.21' apply false
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0' apply false
+    id 'org.jetbrains.kotlin.plugin.compose' version '2.2.21' apply false
 }
 
 allprojects {

--- a/mock/build.gradle
+++ b/mock/build.gradle
@@ -35,16 +35,16 @@ android {
 
 dependencies {
 
-    implementation "com.squareup.okhttp3:mockwebserver:4.12.0"
-    implementation "com.squareup.okhttp3:okhttp-tls:4.9.3"
+    implementation "com.squareup.okhttp3:mockwebserver:5.3.2"
+    implementation "com.squareup.okhttp3:okhttp-tls:5.3.2"
 
-    implementation "com.google.dagger:dagger:2.46.1"
-    kapt "com.google.dagger:dagger-compiler:2.46.1"
+    implementation "com.google.dagger:dagger:2.57.2"
+    kapt "com.google.dagger:dagger-compiler:2.57.2"
 
-    implementation "com.squareup.retrofit2:converter-gson:2.9.0"
+    implementation "com.squareup.retrofit2:converter-gson:3.0.0"
 
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
-    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.10.0'
+    implementation 'androidx.core:core-ktx:1.17.0'
 }
 
 apply from: "${rootProject.projectDir}/mavencentral.gradle"

--- a/mock/src/main/java/com/telefonica/mock/di/MockApiModule.kt
+++ b/mock/src/main/java/com/telefonica/mock/di/MockApiModule.kt
@@ -6,7 +6,6 @@ import com.telefonica.mock.FileReader
 import com.telefonica.mock.ResponseDispatcher
 import dagger.Module
 import dagger.Provides
-import kotlinx.coroutines.Dispatchers
 import okhttp3.mockwebserver.MockWebServer
 import javax.inject.Singleton
 


### PR DESCRIPTION
### :goal_net: What's the goal?
Update libs so that the lib can be used with okhttp 5

### :construction: How do we do it?
- Updated libs
- Added the old icons directly as material icons was removed from material 3 last September https://x.com/riggaroo/status/1971485475866341530

### :blue_book: Documentation changes?
- [x] No docs to update nor create

### :test_tube: How can I test this?
Run the app:

https://github.com/user-attachments/assets/08bed506-cba1-4e2a-baf5-bb42d4f18a66

I've also run it on Smart Wifi updating okhttp to 5.3.2 with composite builds.